### PR TITLE
Make path param regex default more restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ OPTIONS
 
   -o, --out=out                            [default: ./openapi.yaml] Write output result at this DEST location.
 
-  -r, --path-param-regex=path-param-regex  [default: [0-9]|[-$@!~%^*()_+]] Convert Regex matching params into dynamic path
+  -r, --path-param-regex=path-param-regex  [default: ^([0-9]|[-$@!~%^*()_+])+$] Convert Regex matching params into dynamic path
 
   -s, --security-headers=security-headers  [default: {}] Map matching HTTP headers into security headers on request.
 

--- a/man/avantation.1
+++ b/man/avantation.1
@@ -4,7 +4,7 @@ avantation \- build openapi3.0 specification from HAR
 .SH SYNOPSIS
 avantation [HAR]
 .SH DESCRIPTION
-avantation is tool the for generate OpenAPI3.0 from HTTP Archive format(HAR).
+avantation is a tool to generate an OpenAPI 3.0 specification from HTTP Archive format(HAR).
 .SH OPTIONS
 
 .TP
@@ -25,7 +25,7 @@ Separate the common path as base path from \fBHTTP requests\fR
 \fB\-r\fR, \fB\-\-path\-param\-regex\fR
 Converts regex matching paths into dynamic paths.
 .br
-\fBdefault:\fR [0-9]|[-$@!~%^*()_+]
+\fBdefault:\fR ^([0-9]|[-$@!~%^*()_+])+$
 
 .TP
 \fB\-s\fR, \fB\-\-security\-headers\fR
@@ -33,7 +33,7 @@ Map matching \fBHTTP\fR headers into security headers on request.
 .br
 \fBSyntax:\fR
 {
-"\fBheaderNameInHTTPRequest\fR": {Sequrity Scheme Object as per OAS3.0}
+"\fBheaderNameInHTTPRequest\fR": {Security Scheme Object as per OAS3.0}
 }
 .br
 \fBExample:\fR

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ class Avantation extends Command {
         'path-param-regex': flags.string({
             char: 'r',
             description: 'Convert Regex matching params into dynamic path ',
-            default: '[0-9]|[-$@!~%^*()_+]'
+            default: '^([0-9]|[-$@!~%^*()_+])+$'
         }),
         json: flags.boolean({
             char: 'j',
@@ -106,7 +106,7 @@ class Avantation extends Command {
             basePath: flags['base-path'] || '',
             template: template,
             out: flags.out || './openapi.yaml',
-            pathParamRegex: flags['path-param-regex'] || '[0-9]|[-$@!~%^*()_+]',
+            pathParamRegex: flags['path-param-regex'] || '^([0-9]|[-$@!~%^*()_+])+$',
             pipe: pipe,
             json: flags.json,
             disableTag: flags['disable-tag'],


### PR DESCRIPTION
* See https://swagger.io/docs/specification/data-models/data-types/
* `generate-schema` is generating `type: "null"` for responses that have
`null` fields. `"null"` is not a valid OpenAPI data type. This change
sets the "type" to `"string"` if a Data Type cannot be inferred from a
`null` value.