### PR TITLE
Skip HAR entries that don't have a response

### DIFF
--- a/src/apis/avantation.ts
+++ b/src/apis/avantation.ts
@@ -61,6 +61,10 @@ export class AvantationAPI implements Avantation.InputConfig {
     buildEntry(entry: HAR.HarEntry) {
         let url: Avantation.URL = new URL(entry.request.url);
         let method;
+        if (!entry.response) {
+            this.oclif.warn(`Skipping HAR entry without response`);
+            return;
+        }
         entry.response.content.mimeType =
             entry.response.content.mimeType === 'application/json; charset=utf-8'
                 ? 'application/json'


### PR DESCRIPTION
We've found some HAR files that generate entries that don't have a response.  However this is generated, it'd be nice to handle that scenario gracefully.

Without this fix, the converter complains:
```
TypeError: Cannot read properties of undefined (reading 'content')
    at AvantationAPI.buildEntry ([...]/node_modules/avantation/lib/apis/avantation.js:44:24)
```