### PR TITLE
Enable specifying accepted mimeTypes

### DIFF
--- a/src/apis/avantation.ts
+++ b/src/apis/avantation.ts
@@ -42,7 +42,7 @@ export class AvantationAPI implements Avantation.InputConfig {
         this.out = input.out;
         this.pathRegex = new RegExp(this.pathParamRegex);
         this.oclif = oclif;
-        this.mimeTypes = ['application/json', '', 'application/json; charset=utf-8'];
+        this.mimeTypes = input.mimeTypes || ['application/json', '', 'application/json; charset=utf-8'];
         this.disableTag = input.disableTag;
         this.securityHeaders = input.securityHeaders;
         this['http-snippet'] = input['http-snippet'];

--- a/src/interfaces/avantation.ts
+++ b/src/interfaces/avantation.ts
@@ -59,4 +59,5 @@ export interface InputConfig {
     disableTag: boolean;
     securityHeaders: OAS.SecurityMap;
     'http-snippet': boolean;
+    mimeTypes?: string[];
 }


### PR DESCRIPTION
We would like the ability to specify the accepted mime types, which is what this pull request accomplishes. The default list of 

```
['application/json', '', 'application/json; charset=utf-8']
```
is reasonable, but the mime type specification allows for a [media type suffix ](https://en.wikipedia.org/wiki/Media_type#Suffix) which includes `+json` .  Also, some API's are unfortunately _not_ RFC 6838 spec compliant with their mime types and it would be nice to be able to support those HAR files as well.